### PR TITLE
Fix rest playback and add looping

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,21 @@ instrument in GarageBand, you can listen to
 [`demos/track1-180bpm.mp3`](demos/track1-180bpm.mp3).
 
 
+## Hardware and Looping Playback
+
+I developed the sequencer on a Trinket M0 (non-Express SAMD21) to make sure it
+would be small and fast. While I haven't tested on other CircuitPython boards,
+probably the code will run fine, as long as you use a board that supports USB
+MIDI. If you want to use hardwired DIN-5 or TRS MIDI, take a look at the
+midi_tx() callback function defined in code.py.
+
+The current `code.py` configures `board.A0` (silkscreen `1~` on Trinket M0) as
+a digital input to control looping playback. If you don't connect anything to
+`A0`, the sequence will play through once when the code loads. If you connect
+`A0` to `GND`, the sequence plays in a loop. On my Trinket M0, I use this with
+a toggle switch between `GND` and `1~`.
+
+
 ## How to Run the Code
 
 I've been testing this with CircuitPython 9.0.5 on a Trinket M0 (SAMD21), but
@@ -46,7 +61,10 @@ most of the code (all but MIDI out) also runs on desktop python3.
 
 1. Prepare a host computer with something that can play sounds for incoming
    USB MIDI notes on channels 10, 11, 12, and 13. For example, on macOS, you
-   can use the GarageBand app by adding a MIDI track to an empty project.
+   can use the GarageBand app by adding a MIDI track to an empty project. If
+   you only care about drum parts, you could try my browser-based drum synth,
+   [web-midi-drumkit](https://samblenny.github.io/web-midi-drumkit/) (requires
+   Chrome browser for WebMIDI support).
 
 2. Update CircuitPython and bootloader the normal way. (no additional libraries
    are needed)

--- a/README.md
+++ b/README.md
@@ -42,13 +42,12 @@ I developed the sequencer on a Trinket M0 (non-Express SAMD21) to make sure it
 would be small and fast. While I haven't tested on other CircuitPython boards,
 probably the code will run fine, as long as you use a board that supports USB
 MIDI. If you want to use hardwired DIN-5 or TRS MIDI, take a look at the
-midi_tx() callback function defined in code.py.
+`midi_tx()` callback function defined in `code.py`.
 
 The current `code.py` configures `board.A0` (silkscreen `1~` on Trinket M0) as
 a digital input to control looping playback. If you don't connect anything to
 `A0`, the sequence will play through once when the code loads. If you connect
-`A0` to `GND`, the sequence plays in a loop. On my Trinket M0, I use this with
-a toggle switch between `GND` and `1~`.
+`A0` to `GND`, the sequence plays in a loop.
 
 
 ## How to Run the Code

--- a/code.py
+++ b/code.py
@@ -1,11 +1,31 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: Copyright 2024 Sam Blenny
+from board import A0, LED
+from digitalio import DigitalInOut, DriveMode, Pull
 from gc import collect, mem_free
-from time import monotonic
+from time import monotonic, sleep
 import usb_midi
 from txtseq.sequencer import sequencer
 from txtseq.player import Player
 
+
+# Initialize input pin to control looping playback.
+#
+# I chose the A0 name here because most Adafruit CircuitPython board
+# definititions include board.A0, and it often corresponds to a pin with "A0"
+# as its silkscreen. The Trinket M0 is a rare exception with "1~" for A0.
+#
+def init_loop_pin():
+    p = DigitalInOut(A0)  # <-- Change this if you want a different input pin
+    p.pull = Pull.UP
+    return p
+
+# Initialize LED pin (usually D13) to indicate looping playback is on.
+# CAUTION: Some boards don't define board.LED.
+def init_LED():
+    p = DigitalInOut(LED)
+    p.switch_to_output(value=False)
+    return p
 
 # Callback to send raw bytes on the default CircuitPython USB MIDI output port
 def midi_tx(data):
@@ -24,7 +44,7 @@ def main():
 
     collect()               # Start measuring time and memory use
     a = mem_free()          # a: baseline free mem
-    with open('track1.txt', 'rb') as f:
+    with open('track2.txt', 'rb') as f:
         collect()
         b = mem_free()      # b: free mem before parse
         t = monotonic()     # t: timestamp before parse
@@ -33,32 +53,37 @@ def main():
         collect()
         c = mem_free()      # c: free mem after parse
         p(f'[parse time: %s ms]' % int((T - t) * 1000))
-        t = monotonic()     # timestamp before hexdump
-        p()
-        # Hexdump the array.array('L') of midi events packed as uint32 integers
-        for (i, e) in enumerate(db['buf']):
-            p(f"{e:08X}", end=' ')
-            if i % 10 == 9:
-                p()
-        p(f'\n[midi event dump time: %s ms]\n' % int((monotonic() - t) * 1000))
         # Print summary of memory use
-        p('mem_free:', a, b, c, '  diffs:', a-b, b-c)
+        p('\nmem_free:', a, b, c, '  diffs:', a-b, b-c)
 
         # Play MIDI events
         p('\nPlaying on USB MIDI ch10-13...')
         collect()
-        # Player is a generator that is meant to be called frequently to play
-        # MIDI events at their scheduled timestamps. The generator yields
-        # the remaining ms until its next scheduled MIDI event (idle_ms).
-        for idle_ms in Player(db, midi_out_callback=midi_tx, debug=False):
-            if idle_ms > 60:
-                collect()  # gc.collect() if there's lots of spare time
-            if idle_ms > 10:
-                # you can do other work here (check buttons or whatever)
-                pass
-            else:
-                pass
-        p('Done')
+        # This always plays the sequence on the first time through after reset,
+        # then it begins watching the loop-mode input pin. To make the sequence
+        # play as a loop, close the switch between the loop input pin (A0) and
+        # GND. To pause playback, open the switch.
+        loop_pin = init_loop_pin()
+        loop_led = init_LED()
+        first = True
+        while True:
+            loop_led.value = not loop_pin.value
+            if (not first) and loop_pin.value:  # Only loop if loop_pin is low
+                sleep(0.01)
+                continue
+            # Player is a generator that is meant to be called frequently to
+            # play MIDI events at their scheduled timestamps. The generator
+            # yields the remaining ms until its next scheduled MIDI event
+            # (idle_ms).
+            for idle_ms in Player(db, midi_out_callback=midi_tx, debug=False):
+                if idle_ms > 60:
+                    collect()  # gc.collect() if there's lots of spare time
+                if idle_ms > 10:
+                    # you can do other work here (check buttons or whatever)
+                    pass
+                else:
+                    pass
+            first = False
 
 
 main()

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 # Begin by clearing extended attributes from source files because, if they
 # exist, macOS rsync seems to always attempt to copy them to CIRCUITPY.
-xattr -cr txtseq track1.txt code.py
+xattr -cr txtseq track*.txt code.py
 xattr -cr /Volumes/CIRCUITPY/*
 rsync -rcvO --delete --exclude="__main__.py" txtseq/ /Volumes/CIRCUITPY/txtseq
-rsync -cvO track1.txt code.py /Volumes/CIRCUITPY
+rsync -cvO track*.txt code.py /Volumes/CIRCUITPY
 sync

--- a/track2.txt
+++ b/track2.txt
@@ -1,0 +1,6 @@
+U 1/8
+B 120
+
+# Try this with https://samblenny.github.io/web-midi-drumkit/
+
+1 | {Ch}{Ch} {Dh}h {Ch}h {Dh}h | {Ch}{h} {Dh}h {Ch}h {Dh}h |

--- a/txtseq/player.py
+++ b/txtseq/player.py
@@ -15,6 +15,7 @@ def Player(db, midi_out_callback, debug=False):
     ppb = db['ppb']  # pulses per beat (derived from time unit cmd, U)
     bpm = db['bpm']  # beats per minute (from bpm command, B)
     buf = db['buf']  # array.array('L') uint32 of packed midi events
+    end = max(db['ticks'])  # length of track (including rests at the end!)
     # preload a function to get milliseconds
     try:
         # The supervisor module only works on CircuitPython
@@ -52,3 +53,11 @@ def Player(db, midi_out_callback, debug=False):
         if(debug):
             # Print ms timestamp for this event (for checking latency)
             print(now)
+    # If sequence ends on a rest, wait until the end of the rest
+    tNext = mspp * end
+    now = ((ms() - t0) & mask)
+    while tNext > now:
+        yield tNext - now
+        now = ((ms() - t0) & mask)
+    if(debug):
+        print(now)


### PR DESCRIPTION
Previously, rests at the end of a sequence got skipped, so looping tracks sounded wrong. This makes sure that sequences include the proper amount of silence at the end so that they play for the full time of their allotted number of beats.

Also, there's a new switching looping mode. Connecting `A0` and `GND` makes the sequence loop. Leaving them unconnected just plays the sequence once when the code loads.